### PR TITLE
Use long_description_content_type': 'text/markdown' in README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     license='LICENSE.txt',
     description='Downloads and formats search results from dblp',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     install_requires=[
         "beautifulsoup4>=4.3.2",
         "pandas>=0.16.2",


### PR DESCRIPTION
This will make the page https://pypi.org/project/dblp/ actually render the markdown (like in https://pypi.org/project/mpu/ )